### PR TITLE
Update tests per CatalogDBObject API change

### DIFF
--- a/tests/testCatalogs.py
+++ b/tests/testCatalogs.py
@@ -75,9 +75,9 @@ class InstanceCatalogTestCase(unittest.TestCase):
         self.obsMd = ObservationMetaData(boundType = 'circle', unrefractedRA = 210.0, unrefractedDec = -60.0,
                      boundLength=1.75, mjd=52000.,bandpassName='r')
 
-        self.mystars = CatalogDBObject.from_objid('teststars', address='sqlite:///icStarTestDatabase.db')
+        self.mystars = CatalogDBObject.from_objid('teststars', driver='sqlite', database='icStarTestDatabase.db')
 
-        self.mygals = CatalogDBObject.from_objid('testgals', address='sqlite:///icGalTestDatabase.db')
+        self.mygals = CatalogDBObject.from_objid('testgals', driver='sqlite', database='icGalTestDatabase.db')
 
         self.basedir = eups.productDir('sims_catalogs_measures')+"/tests/"
 
@@ -155,7 +155,7 @@ class boundingBoxTest(unittest.TestCase):
                         boundLength=numpy.array([0.5*(self.RAmax-self.RAmin),0.5*(self.DECmax-self.DECmin)]),
                         mjd=52000., bandpassName='r')
 
-        self.mystars = CatalogDBObject.from_objid('teststars', address='sqlite:///bboxStarTestDatabase.db')
+        self.mystars = CatalogDBObject.from_objid('teststars', driver='sqlite', database='bboxStarTestDatabase.db')
 
     def tearDown(self):
         del self.obsMdCirc

--- a/tests/testColumnOrigins.py
+++ b/tests/testColumnOrigins.py
@@ -37,7 +37,8 @@ class testDBobject(CatalogDBObject):
     idColKey = 'id'
     #Make this implausibly large?
     appendint = 1023
-    dbAddress = 'sqlite:///colOriginsTestDatabase.db'
+    database = 'colOriginsTestDatabase.db'
+    driver = 'sqlite'
     raColName = 'ra'
     decColName = 'decl'
     columns = [('objid', 'id', int),

--- a/tests/testInstanceCatalog.py
+++ b/tests/testInstanceCatalog.py
@@ -88,7 +88,8 @@ def createCannotBeNullTestDB(filename=None, add_nans=True):
     return output
 
 class myCannotBeNullDBObject(CatalogDBObject):
-    dbAddress = 'sqlite:///cannotBeNullTest.db'
+    driver = 'sqlite'
+    database = 'cannotBeNullTest.db'
     tableid = 'testTable'
     objid = 'cannotBeNull'
     idColKey = 'id'
@@ -154,7 +155,7 @@ class InstanceCatalogMetaDataTest(unittest.TestCase):
             os.unlink('testInstanceCatalogDatabase.db')
 
     def setUp(self):
-        self.myDB = myTestStars(address = 'sqlite:///testInstanceCatalogDatabase.db')
+        self.myDB = myTestStars(driver='sqlite', database='testInstanceCatalogDatabase.db')
 
     def tearDown(self):
         del self.myDB
@@ -338,7 +339,7 @@ class InstanceCatalogMetaDataTest(unittest.TestCase):
         """
         dbName = 'valueTestDB.db'
         baselineData = createCannotBeNullTestDB(filename=dbName, add_nans=False)
-        db = myCannotBeNullDBObject(address='sqlite:///' + dbName)
+        db = myCannotBeNullDBObject(driver='sqlite', database=dbName)
         dtype = numpy.dtype([('n1',float), ('n2',float), ('n3',float), ('difference', float)])
         cat = cartoonValueCatalog(db, column_outputs = ['n3','difference'])
 
@@ -372,7 +373,7 @@ class InstanceCatalogMetaDataTest(unittest.TestCase):
 
         dbName = 'valueTestDB.db'
         baselineData = createCannotBeNullTestDB(filename=dbName, add_nans=False)
-        db = myCannotBeNullDBObject(address='sqlite:///' + dbName)
+        db = myCannotBeNullDBObject(driver='sqlite', database=dbName)
         cat = otherCartoonValueCatalog(db)
         columns = ['n1', 'n2', 'n3', 'difference']
         for col in columns:


### PR DESCRIPTION
CatalogDBObject requires driver/database names as input instead of addresses.
