### PR TITLE
Feature/sim 1151/rewrite variability mixin

### DIFF
--- a/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
@@ -251,7 +251,7 @@ class InstanceCatalog(object):
                     if col not in self._column_outputs:
                         self._column_outputs.append(col)
 
-        self.all_calculated_columns =[] #a list of all the columns referenced by self.column_by_name
+        self._actually_calculated_columns =[] #a list of all the columns referenced by self.column_by_name
         self.site = self.obs_metadata.site
         self.unrefractedRA = self.obs_metadata.unrefractedRA
         self.unrefractedDec = self.obs_metadata.unrefractedDec
@@ -347,8 +347,8 @@ class InstanceCatalog(object):
     def column_by_name(self, column_name, *args, **kwargs):
         """Given a column name, return the column data"""
 
-        if isinstance(self._current_chunk, _MimicRecordArray) and column_name not in self.all_calculated_columns:
-            self.all_calculated_columns.append(column_name)
+        if isinstance(self._current_chunk, _MimicRecordArray) and column_name not in self._actually_calculated_columns:
+            self._actually_calculated_columns.append(column_name)
 
         getfunc = "get_%s" % column_name
         if hasattr(self, getfunc):

--- a/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
@@ -155,7 +155,7 @@ class InstanceCatalog(object):
     catalog_type = 'instance_catalog'
     column_outputs = None
     default_columns = []
-    cannot_be_null = [] #a list of columns which, if null, cause a row not to be printed by write_catalog()
+    cannot_be_null = [] # a list of columns which, if null, cause a row not to be printed by write_catalog()
     default_formats = {'S':'%s', 'f':'%.4f', 'i':'%i'}
     override_formats = {}
     transformations = {}
@@ -228,8 +228,8 @@ class InstanceCatalog(object):
         self.db_obj = db_obj
         self._current_chunk = None
 
-        #this dict will contain information telling the user where the columns in
-        #the catalog come from
+        # this dict will contain information telling the user where the columns in
+        # the catalog come from
         self._column_origins = {}
 
         if obs_metadata is not None:
@@ -251,7 +251,7 @@ class InstanceCatalog(object):
                     if col not in self._column_outputs:
                         self._column_outputs.append(col)
 
-        self._actually_calculated_columns =[] #a list of all the columns referenced by self.column_by_name
+        self._actually_calculated_columns =[] # a list of all the columns referenced by self.column_by_name
         self.site = self.obs_metadata.site
         self.unrefractedRA = self.obs_metadata.unrefractedRA
         self.unrefractedDec = self.obs_metadata.unrefractedDec
@@ -266,17 +266,17 @@ class InstanceCatalog(object):
 
         self._column_cache = {}
 
-        #self._column_origins_switch tells column_by_name to log where it is getting
-        #the columns in self._column_origins (we only want to do that once)
+        # self._column_origins_switch tells column_by_name to log where it is getting
+        # the columns in self._column_origins (we only want to do that once)
         self._column_origins_switch = True
 
-        #now we will create and populate a list containing the names of
-        #all of the columns which this InstanceCatalog can return.
-        #Note: this needs to happen before self._check_requirements()
-        #is called in case any getters depend on the contents of
-        #_all_available_columns.  That way, self._check_requirements()
-        #can verify that the getter will run the way it is actually
-        #being called.
+        # now we will create and populate a list containing the names of
+        # all of the columns which this InstanceCatalog can return.
+        # Note: this needs to happen before self._check_requirements()
+        # is called in case any getters depend on the contents of
+        # _all_available_columns.  That way, self._check_requirements()
+        # can verify that the getter will run the way it is actually
+        # being called.
         self._all_available_columns = []
 
         for name in self.db_obj.columnMap.keys():
@@ -304,9 +304,9 @@ class InstanceCatalog(object):
         if not hasattr(self,'_column_outputs'):
             self._column_outputs = []
 
-            #because asking for a compound_column means asking for
-            #its individual sub-columns, which means those columns
-            #will get listed twice in the catalog
+            # because asking for a compound_column means asking for
+            # its individual sub-columns, which means those columns
+            # will get listed twice in the catalog
             for name in self._all_available_columns:
                 if name not in self._compound_columns:
                     self._column_outputs.append(name)
@@ -391,7 +391,7 @@ class InstanceCatalog(object):
             else:
                 self._active_columns.append(col)
 
-        self._column_origins_switch = False #do not want to log column origins any more
+        self._column_origins_switch = False # do not want to log column origins any more
 
         if len(missing_cols) > 0:
             nodefault = []
@@ -399,10 +399,10 @@ class InstanceCatalog(object):
                 if col not in defaults:
                     nodefault.append(col)
                 else:
-                    #Because some earlier part of the code copies default columns
-                    #into the same place as columns that exist natively in the
-                    #database, this is where we have to mark columns that are
-                    #set by default
+                    # Because some earlier part of the code copies default columns
+                    # into the same place as columns that exist natively in the
+                    # database, this is where we have to mark columns that are
+                    # set by default
                     self._column_origins[col] = 'default column'
 
             if len(nodefault) > 0:
@@ -452,7 +452,7 @@ class InstanceCatalog(object):
                                                  constraint=self.constraint,
                                                  chunk_size=chunk_size)
 
-        #find the indices of columns that cannot be null
+        # find the indices of columns that cannot be null
         cannotBeNullDexes = []
         for (i,col) in enumerate(self.iter_column_names()):
             if col in self.cannot_be_null:
@@ -474,9 +474,9 @@ class InstanceCatalog(object):
             file_handle.writelines(template % line
                                    for line in zip(*chunk_cols)
                                    if numpy.array([not is_null(line[i]) for i in cannotBeNullDexes]).all())
-                                   #the last boolean in this line causes a row not to be printed if it has
-                                   #a null value in one of the columns that cannot be null; it is ignored
-                                   #if no olumns are specified by cannot_be_null
+                                   # the last boolean in this line causes a row not to be printed if it has
+                                   # a null value in one of the columns that cannot be null; it is ignored
+                                   # if no olumns are specified by cannot_be_null
 
         file_handle.close()
 

--- a/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
@@ -274,7 +274,12 @@ class InstanceCatalog(object):
         self._column_origins_switch = True
 
         #now we will create and populate a list containing the names of
-        #all of the columns which this InstanceCatalog can return
+        #all of the columns which this InstanceCatalog can return.
+        #Note: this needs to happen before self._check_requirements()
+        #is called in case any getters depend on the contents of
+        #_all_available_columns.  That way, self._check_requirements()
+        #can verify that the getter will run the way it is actually
+        #being called.
         self._all_available_columns = []
 
         for name in self.db_obj.columnMap.keys():

--- a/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
@@ -264,9 +264,6 @@ class InstanceCatalog(object):
 
         self.refIdCol = self.db_obj.getIdColKey()
 
-        if not hasattr(self,'_column_outputs'):
-            self._column_outputs = self._all_columns()
-
         self._column_cache = {}
 
         #self._column_origins_switch tells column_by_name to log where it is getting
@@ -283,38 +280,32 @@ class InstanceCatalog(object):
         self._all_available_columns = []
 
         for name in self.db_obj.columnMap.keys():
-            self._all_available_columns.append(name)
+            if name not in self._all_available_columns:
+                self._all_available_columns.append(name)
 
         for name in self._compound_column_names:
-            self._all_available_columns.append(name)
+            if name not in self._all_available_columns:
+                self._all_available_columns.append(name)
 
         for name in self._compound_columns:
-            self._all_available_columns.append(name)
+            if name not in self._all_available_columns:
+                self._all_available_columns.append(name)
 
         for name in dir(self):
-            if name[:4]=='get_':
+            if name[:4]==('get_'):
                 columnName = name[4:]
                 if columnName not in self._all_available_columns:
                     self._all_available_columns.append(columnName)
-            elif name[:8]=='default_':
+            elif name[:8] == 'default_':
                 columnName = name[8:]
                 if columnName not in self._all_available_columns:
                     self._all_available_columns.append(columnName)
 
+        if not hasattr(self,'_column_outputs'):
+            self._column_outputs = self._all_available_columns
 
         self._check_requirements()
 
-    def _all_columns(self):
-        """
-        Return a list of all available column names, from those provided
-        by the instance catalog and those provided by the database
-        """
-        columns = set(self.db_obj.columnMap.keys())
-        getfuncs = [func for func in dir(self) if func.startswith('get_')]
-        defaultfuncs = [func for func in dir(self) if func.startswith('default')]
-        columns.update([func.strip('get_') for func in getfuncs])
-        columns.update([func.strip('default_') for func in defaultfuncs])
-        return list(columns)
 
     def _set_current_chunk(self, chunk, column_cache=None):
         """Set the current chunk and clear the column cache"""

--- a/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
@@ -274,19 +274,23 @@ class InstanceCatalog(object):
         self._column_origins_switch = True
 
         #now we will create and populate a list containing the names of
-        #all of the columns for which getter methods exist
-        self._all_getters = []
+        #all of the columns which this InstanceCatalog can return
+        self._all_available_columns = []
+
+        for name in self.db_obj.columnMap.keys():
+            self._all_available_columns.append(name)
+
         for name in self._compound_column_names:
-            self._all_getters.append(name)
+            self._all_available_columns.append(name)
 
         for name in self._compound_columns:
-            self._all_getters.append(name)
+            self._all_available_columns.append(name)
 
         for name in dir(self):
             if name[:4]=='get_':
                 columnName = name[4:]
-                if columnName not in self._all_getters:
-                    self._all_getters.append(columnName)
+                if columnName not in self._all_available_columns:
+                    self._all_available_columns.append(columnName)
 
         self._check_requirements()
 

--- a/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
@@ -292,7 +292,7 @@ class InstanceCatalog(object):
                 self._all_available_columns.append(name)
 
         for name in dir(self):
-            if name[:4]==('get_'):
+            if name[:4] == 'get_':
                 columnName = name[4:]
                 if columnName not in self._all_available_columns:
                     self._all_available_columns.append(columnName)
@@ -302,7 +302,14 @@ class InstanceCatalog(object):
                     self._all_available_columns.append(columnName)
 
         if not hasattr(self,'_column_outputs'):
-            self._column_outputs = self._all_available_columns
+            self._column_outputs = []
+
+            #because asking for a compound_column means asking for
+            #its individual sub-columns, which means those columns
+            #will get listed twice in the catalog
+            for name in self._all_available_columns:
+                if name not in self._compound_columns:
+                    self._column_outputs.append(name)
 
         self._check_requirements()
 

--- a/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
@@ -291,6 +291,11 @@ class InstanceCatalog(object):
                 columnName = name[4:]
                 if columnName not in self._all_available_columns:
                     self._all_available_columns.append(columnName)
+            elif name[:8]=='default_':
+                columnName = name[8:]
+                if columnName not in self._all_available_columns:
+                    self._all_available_columns.append(columnName)
+
 
         self._check_requirements()
 

--- a/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
+++ b/python/lsst/sims/catalogs/measures/instance/InstanceCatalog.py
@@ -273,6 +273,21 @@ class InstanceCatalog(object):
         #the columns in self._column_origins (we only want to do that once)
         self._column_origins_switch = True
 
+        #now we will create and populate a list containing the names of
+        #all of the columns for which getter methods exist
+        self._all_getters = []
+        for name in self._compound_column_names:
+            self._all_getters.append(name)
+
+        for name in self._compound_columns:
+            self._all_getters.append(name)
+
+        for name in dir(self):
+            if name[:4]=='get_':
+                columnName = name[4:]
+                if columnName not in self._all_getters:
+                    self._all_getters.append(columnName)
+
         self._check_requirements()
 
     def _all_columns(self):

--- a/tests/testColumnOrigins.py
+++ b/tests/testColumnOrigins.py
@@ -6,9 +6,15 @@ import lsst.utils.tests as utilsTests
 from lsst.sims.catalogs.measures.instance import InstanceCatalog, cached, compound
 from lsst.sims.catalogs.generation.db import CatalogDBObject
 
-def makeTestDB(size=10, name=None, **kwargs):
+def makeTestDB(name, size=10, **kwargs):
     """
     Make a test database
+
+    @param [in] name is a string indicating the name of the database file
+    to be created
+
+    @param [in] size is an int indicating the number of objects to include
+    in the database (default=10)
     """
     conn = sqlite3.connect(name)
     c = conn.cursor()
@@ -115,7 +121,7 @@ class testColumnOrigins(unittest.TestCase):
         if os.path.exists(cls.dbName):
             os.unlink(cls.dbName)
 
-        makeTestDB(name=cls.dbName)
+        makeTestDB(cls.dbName)
 
     @classmethod
     def tearDownClass(cls):
@@ -276,7 +282,7 @@ class AllAvailableColumns(unittest.TestCase):
         if os.path.exists(cls.dbName):
             os.unlink(cls.dbName)
 
-        makeTestDB(name=cls.dbName)
+        makeTestDB(cls.dbName)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/testColumnOrigins.py
+++ b/tests/testColumnOrigins.py
@@ -238,7 +238,7 @@ class myDependentColumnsClass_shouldPass(InstanceCatalog):
 
     def get_dd(self):
 
-        if 'ee' in self._all_getters:
+        if 'ee' in self._all_available_columns:
             delta = self.column_by_name('ee')
         else:
             delta = self.column_by_name('bb')
@@ -252,7 +252,7 @@ class myDependentColumnsClass_shouldFail(InstanceCatalog):
 
     def get_dd(self):
 
-        if 'ee' in self._all_getters:
+        if 'ee' in self._all_available_columns:
             delta = self.column_by_name('ee')
         else:
             delta = self.column_by_name('bb')
@@ -265,7 +265,7 @@ class myDependentColumnsClass_shouldFail(InstanceCatalog):
 class testColumnRegistries(unittest.TestCase):
     """
     This will contain a unit test to verify that the InstanceCatalog class
-    self._all_getters contains all of the information it should
+    self._all_available_columns contains all of the information it should
     """
 
     @classmethod
@@ -287,20 +287,28 @@ class testColumnRegistries(unittest.TestCase):
 
     def testAllGetters(self):
         """
-        test that the self._all_getters list contains all of the columns
-        for which there are getter methods
+        test that the self._all_available_columns list contains all of the columns
+        definedin an InstanceCatalog and its CatalogDBObject
         """
-
         cat = myDummyCatalogClass(self.db, column_outputs=['aa'])
-        self.assertTrue('cc' in cat._all_getters)
-        self.assertTrue('dd' in cat._all_getters)
-        self.assertTrue('ee' in cat._all_getters)
-        self.assertTrue('ff' in cat._all_getters)
-        self.assertTrue('compound' in cat._all_getters)
+        self.assertTrue('cc' in cat._all_available_columns)
+        self.assertTrue('dd' in cat._all_available_columns)
+        self.assertTrue('ee' in cat._all_available_columns)
+        self.assertTrue('ff' in cat._all_available_columns)
+        self.assertTrue('compound' in cat._all_available_columns)
+        self.assertTrue('id' in cat._all_available_columns)
+        self.assertTrue('aa' in cat._all_available_columns)
+        self.assertTrue('bb' in cat._all_available_columns)
+        self.assertTrue('ra' in cat._all_available_columns)
+        self.assertTrue('decl' in cat._all_available_columns)
+        self.assertTrue('decJ2000' in cat._all_available_columns)
+        self.assertTrue('raJ2000' in cat._all_available_columns)
+        self.assertTrue('objid' in cat._all_available_columns)
+
 
     def testDependentColumns(self):
         """
-        We want to be able to use self._all_getters to change the calculation
+        We want to be able to use self._all_available_columns to change the calculation
         of columns on the fly (i.e. if a column exists, then use it to calculate
         another column; if it does not, ignore it).  This method tests whether
         or not that scheme will work.

--- a/tests/testColumnOrigins.py
+++ b/tests/testColumnOrigins.py
@@ -6,11 +6,11 @@ import lsst.utils.tests as utilsTests
 from lsst.sims.catalogs.measures.instance import InstanceCatalog, cached, compound
 from lsst.sims.catalogs.generation.db import CatalogDBObject
 
-def makeTestDB(size=10, **kwargs):
+def makeTestDB(size=10, name=None, **kwargs):
     """
     Make a test database
     """
-    conn = sqlite3.connect('colOriginsTestDatabase.db')
+    conn = sqlite3.connect(name)
     c = conn.cursor()
 #    try:
     c.execute('''CREATE TABLE testTable
@@ -31,8 +31,8 @@ def makeTestDB(size=10, **kwargs):
     conn.commit()
     conn.close()
 
-class testDBobject(CatalogDBObject):
-    objid = 'testDBobject'
+class testDBObject(CatalogDBObject):
+    objid = 'testDBObject'
     tableid = 'testTable'
     idColKey = 'id'
     #Make this implausibly large?
@@ -111,18 +111,19 @@ class testColumnOrigins(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if os.path.exists('colOriginsTestDatabase.db'):
-            os.unlink('colOriginsTestDatabase.db')
+        cls.dbName = 'colOriginsTestDatabase.db'
+        if os.path.exists(cls.dbName):
+            os.unlink(cls.dbName)
 
-        makeTestDB()
+        makeTestDB(name=cls.dbName)
 
     @classmethod
     def tearDownClass(cls):
-        if os.path.exists('colOriginsTestDatabase.db'):
-            os.unlink('colOriginsTestDatabase.db')
+        if os.path.exists(cls.dbName):
+            os.unlink(cls.dbName)
 
     def setUp(self):
-        self.myDBobject = testDBobject()
+        self.myDBobject = testDBObject(address='sqlite:///'+self.dbName)
         self.mixin1Name = '<class \'__main__.mixin1\'>'
         self.mixin2Name = '<class \'__main__.mixin2\'>'
         self.mixin3Name = '<class \'__main__.mixin3\'>'

--- a/tests/testColumnOrigins.py
+++ b/tests/testColumnOrigins.py
@@ -218,10 +218,62 @@ class testColumnOrigins(unittest.TestCase):
         self.assertEqual(str(myCatalog._column_origins['cc']),self.mixin3Name)
         self.assertEqual(str(myCatalog._column_origins['dd']),self.mixin1Name)
 
+
+class myDummyCatalogClass(InstanceCatalog):
+
+    def get_cc(self):
+        return self.column_by_name('aa')+1.0
+
+    @compound('dd','ee','ff')
+    def get_compound(self):
+        return numpy.array([
+                           self.column_by_name('aa')+2.0,
+                           self.column_by_name('aa')+3.0,
+                           self.column_by_name('aa')+4.0
+                           ])
+
+class testColumnRegistries(unittest.TestCase):
+    """
+    This will contain a unit test to verify that the InstanceCatalog class
+    self._all_getters contains all of the information it should
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.dbName = 'allGettersTestDatabase.db'
+        if os.path.exists(cls.dbName):
+            os.unlink(cls.dbName)
+
+        makeTestDB(name=cls.dbName)
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(cls.dbName):
+            os.unlink(cls.dbName)
+
+    def setUp(self):
+        self.db = testDBObject(address='sqlite:///'+self.dbName)
+
+
+    def testAllGetters(self):
+        """
+        test that the self._all_getters list contains all of the columns
+        for which there are getter methods
+        """
+
+        cat = myDummyCatalogClass(self.db, column_outputs=['aa'])
+        self.assertTrue('cc' in cat._all_getters)
+        self.assertTrue('dd' in cat._all_getters)
+        self.assertTrue('ee' in cat._all_getters)
+        self.assertTrue('ff' in cat._all_getters)
+        self.assertTrue('compound' in cat._all_getters)
+
+
 def suite():
     utilsTests.init()
     suites = []
     suites += unittest.makeSuite(testColumnOrigins)
+    suites += unittest.makeSuite(testColumnRegistries)
     return unittest.TestSuite(suites)
 
 def run(shouldExit = False):

--- a/tests/testColumnOrigins.py
+++ b/tests/testColumnOrigins.py
@@ -221,6 +221,8 @@ class testColumnOrigins(unittest.TestCase):
 
 class myDummyCatalogClass(InstanceCatalog):
 
+    default_columns = [('sillyDefault', 2.0, float)]
+
     def get_cc(self):
         return self.column_by_name('aa')+1.0
 
@@ -304,6 +306,7 @@ class testColumnRegistries(unittest.TestCase):
         self.assertTrue('decJ2000' in cat._all_available_columns)
         self.assertTrue('raJ2000' in cat._all_available_columns)
         self.assertTrue('objid' in cat._all_available_columns)
+        self.assertTrue('sillyDefault' in cat._all_available_columns)
 
 
     def testDependentColumns(self):

--- a/tests/testColumnOrigins.py
+++ b/tests/testColumnOrigins.py
@@ -129,7 +129,7 @@ class testColumnOrigins(unittest.TestCase):
             os.unlink(cls.dbName)
 
     def setUp(self):
-        self.myDBobject = testDBObject(address='sqlite:///'+self.dbName)
+        self.myDBobject = testDBObject(database=self.dbName)
         self.mixin1Name = '<class \'__main__.mixin1\'>'
         self.mixin2Name = '<class \'__main__.mixin2\'>'
         self.mixin3Name = '<class \'__main__.mixin3\'>'
@@ -290,7 +290,7 @@ class AllAvailableColumns(unittest.TestCase):
             os.unlink(cls.dbName)
 
     def setUp(self):
-        self.db = testDBObject(address='sqlite:///'+self.dbName)
+        self.db = testDBObject(database=self.dbName)
 
 
     def testAllGetters(self):

--- a/tests/testColumnOrigins.py
+++ b/tests/testColumnOrigins.py
@@ -264,7 +264,7 @@ class myDependentColumnsClass_shouldFail(InstanceCatalog):
     def get_ee(self):
         return self.column_by_name('aa')+self.column_by_name('doesNotExist')
 
-class testColumnRegistries(unittest.TestCase):
+class AllAvailableColumns(unittest.TestCase):
     """
     This will contain a unit test to verify that the InstanceCatalog class
     self._all_available_columns contains all of the information it should
@@ -338,7 +338,7 @@ def suite():
     utilsTests.init()
     suites = []
     suites += unittest.makeSuite(testColumnOrigins)
-    suites += unittest.makeSuite(testColumnRegistries)
+    suites += unittest.makeSuite(AllAvailableColumns)
     return unittest.TestSuite(suites)
 
 def run(shouldExit = False):

--- a/tests/testInstanceCatalog.py
+++ b/tests/testInstanceCatalog.py
@@ -305,7 +305,7 @@ class InstanceCatalogMetaDataTest(unittest.TestCase):
         columnsShouldBe = ['raJ2000', 'decJ2000', 'properMotionRa', 'properMotionDec']
 
         for col in columnsShouldBe:
-            self.assertTrue(col in testCat.all_calculated_columns)
+            self.assertTrue(col in testCat._actually_calculated_columns)
 
         generatedColumns = []
         for col in testCat.iter_column_names():
@@ -345,7 +345,7 @@ class InstanceCatalogMetaDataTest(unittest.TestCase):
 
         columns = ['n1', 'n2', 'n3', 'difference']
         for col in columns:
-            self.assertTrue(col in cat.all_calculated_columns)
+            self.assertTrue(col in cat._actually_calculated_columns)
 
         cat.write_catalog('cartoonValCat.txt')
         testData = numpy.genfromtxt('cartoonValCat.txt', dtype=dtype, delimiter=',')
@@ -362,7 +362,7 @@ class InstanceCatalogMetaDataTest(unittest.TestCase):
 
     def testAllCalculatedColumns(self):
         """
-        Unit test to make sure that all_calculated_columns contains all of the dependent columns
+        Unit test to make sure that _actually_calculated_columns contains all of the dependent columns
         """
         class otherCartoonValueCatalog(InstanceCatalog):
             column_outputs = ['n1', 'n2', 'difference']
@@ -377,7 +377,7 @@ class InstanceCatalogMetaDataTest(unittest.TestCase):
         cat = otherCartoonValueCatalog(db)
         columns = ['n1', 'n2', 'n3', 'difference']
         for col in columns:
-            self.assertTrue(col in cat.all_calculated_columns)
+            self.assertTrue(col in cat._actually_calculated_columns)
 
         if os.path.exists('valueTestDB.db'):
             os.unlink('valueTestDB.db')


### PR DESCRIPTION
This pull request creates a list _all_available_columns which contains the names of all of the columns a given InstanceCatalog knows how to calculate.  This is how the new Variability mixins can tell whether or not they contain the delta_magnitude columns necessary for implementing variability.
