### PR TITLE
Bugfix/sim 1315/registry bug

### DIFF
--- a/python/lsst/sims/catalogs/measures/instance/decorators.py
+++ b/python/lsst/sims/catalogs/measures/instance/decorators.py
@@ -59,7 +59,8 @@ def register_class(cls):
     for methodname in dir(cls):
         method=getattr(cls, methodname)
         if hasattr(method, '_registryKey'):
-            cls._methodRegistry.update({method._registryKey:method})
+            if method._registryKey not in cls._methodRegistry:
+                cls._methodRegistry.update({method._registryKey:method})
     return cls
 
 def register_method(key):

--- a/python/lsst/sims/catalogs/measures/instance/decorators.py
+++ b/python/lsst/sims/catalogs/measures/instance/decorators.py
@@ -54,8 +54,7 @@ def compound(*colnames):
     return wrapper
 
 def register_class(cls):
-    if not hasattr(cls, '_methodRegistry'):
-        cls._methodRegistry = {}
+    cls._methodRegistry = {}
     for methodname in dir(cls):
         method=getattr(cls, methodname)
         if hasattr(method, '_registryKey'):

--- a/tests/testMethodRegistry.py
+++ b/tests/testMethodRegistry.py
@@ -45,20 +45,14 @@ class MethodRegistryTestCase(unittest.TestCase):
         """
         Test that the register_class and register_method decorators
         behave appropriately and preserve inheritance.
-
-        Above, we have created a bunch of classes that inherit from
-        each other, each with its own method registry.  Because of the
-        way the decorators work, when you create a daughter class with
-        a method registry, it alters the parent class's registry (i.e.
-        after creating ClassB, ClassA's registry will contain _b_method,
-        even though ClassA does not contain _b_method.  The test below
-        verifies that, even though this is the case, you still cannot
-        call _b_method from Class A.  The test also verifies that methods
-        which are inherited can be called via the registry.
         """
 
         aa = ClassA()
         self.assertTrue(aa.call('a')=='a')
+
+        # below, we test to make sure that methods which
+        # should not be in ClassA's _methodRegistry are not
+        # spuriously added to the registry
         self.assertRaises(KeyError, aa.call, 'b')
         self.assertRaises(KeyError, aa.call, 'c')
         self.assertRaises(KeyError, aa.call, 'd')

--- a/tests/testMethodRegistry.py
+++ b/tests/testMethodRegistry.py
@@ -59,27 +59,27 @@ class MethodRegistryTestCase(unittest.TestCase):
 
         aa = ClassA()
         self.assertTrue(aa.call('a')=='a')
-        self.assertRaises(TypeError, aa.call, 'b')
-        self.assertRaises(TypeError, aa.call, 'c')
-        self.assertRaises(TypeError, aa.call, 'd')
+        self.assertRaises(KeyError, aa.call, 'b')
+        self.assertRaises(KeyError, aa.call, 'c')
+        self.assertRaises(KeyError, aa.call, 'd')
 
         bb = ClassB()
         self.assertTrue(bb.call('a')=='a')
         self.assertTrue(bb.call('b')=='b')
-        self.assertRaises(TypeError, bb.call, 'c')
-        self.assertRaises(TypeError, bb.call, 'd')
+        self.assertRaises(KeyError, bb.call, 'c')
+        self.assertRaises(KeyError, bb.call, 'd')
 
         cc = ClassC()
         self.assertTrue(cc.call('a')=='a')
         self.assertTrue(cc.call('b')=='b')
         self.assertTrue(cc.call('c')=='c')
-        self.assertRaises(TypeError, cc.call, 'd')
+        self.assertRaises(KeyError, cc.call, 'd')
 
         dd = ClassD()
         self.assertTrue(dd.call('a')=='a')
         self.assertTrue(dd.call('d')=='d')
-        self.assertRaises(TypeError, dd.call, 'b')
-        self.assertRaises(TypeError, dd.call, 'c')
+        self.assertRaises(KeyError, dd.call, 'b')
+        self.assertRaises(KeyError, dd.call, 'c')
 
 
 

--- a/tests/testMethodRegistry.py
+++ b/tests/testMethodRegistry.py
@@ -1,0 +1,100 @@
+from __future__ import with_statement
+import unittest
+import lsst.utils.tests as utilsTests
+from lsst.sims.catalogs.measures.instance import register_class, register_method
+
+@register_class
+class ClassA(object):
+
+    def call(self, key):
+        return self._methodRegistry[key](self)
+
+    @register_method('a')
+    def _a_method(self):
+        return 'a'
+
+
+@register_class
+class ClassB(ClassA):
+
+    @register_method('b')
+    def _b_method(self):
+        return 'b'
+
+
+@register_class
+class ClassC(ClassB):
+
+    @register_method('c')
+    def _c_method(self):
+        return 'c'
+
+
+@register_class
+class ClassD(ClassA):
+
+    @register_method('d')
+    def _d_method(self):
+        return 'd'
+
+
+
+class MethodRegistryTestCase(unittest.TestCase):
+
+    def testMethodInheritance(self):
+        """
+        Test that the register_class and register_method decorators
+        behave appropriately and preserve inheritance.
+
+        Above, we have created a bunch of classes that inherit from
+        each other, each with its own method registry.  Because of the
+        way the decorators work, when you create a daughter class with
+        a method registry, it alters the parent class's registry (i.e.
+        after creating ClassB, ClassA's registry will contain _b_method,
+        even though ClassA does not contain _b_method.  The test below
+        verifies that, even though this is the case, you still cannot
+        call _b_method from Class A.  The test also verifies that methods
+        which are inherited can be called via the registry.
+        """
+
+        aa = ClassA()
+        self.assertTrue(aa.call('a')=='a')
+        self.assertRaises(TypeError, aa.call, 'b')
+        self.assertRaises(TypeError, aa.call, 'c')
+        self.assertRaises(TypeError, aa.call, 'd')
+
+        bb = ClassB()
+        self.assertTrue(bb.call('a')=='a')
+        self.assertTrue(bb.call('b')=='b')
+        self.assertRaises(TypeError, bb.call, 'c')
+        self.assertRaises(TypeError, bb.call, 'd')
+
+        cc = ClassC()
+        self.assertTrue(cc.call('a')=='a')
+        self.assertTrue(cc.call('b')=='b')
+        self.assertTrue(cc.call('c')=='c')
+        self.assertRaises(TypeError, cc.call, 'd')
+
+        dd = ClassD()
+        self.assertTrue(dd.call('a')=='a')
+        self.assertTrue(dd.call('d')=='d')
+        self.assertRaises(TypeError, dd.call, 'b')
+        self.assertRaises(TypeError, dd.call, 'c')
+
+
+
+
+def suite():
+    """Returns a suite containing all the test cases in this module."""
+    utilsTests.init()
+    suites = []
+    suites += unittest.makeSuite(MethodRegistryTestCase)
+
+    return unittest.TestSuite(suites)
+
+def run(shouldExit=False):
+    """Run the tests"""
+    utilsTests.run(suite(), shouldExit)
+
+if __name__ == "__main__":
+    run(True)


### PR DESCRIPTION
The way that InstanceCatalogs handle variability is that any class which inherits from the Variability mixins gets a _methodRegistry which is a dict pointing to all of the variability methods defined for that class.  The database contains a column which refers to the keys of that dict, which is how InstanceCatalog knows which variability method to call for which object.  The _methodRegistry is created using the decorators register_method and register_class which are defined in this package (in the file instance/dectorators.py).

Unfortunately, the way the decorators were originally written, if class A inherits from class B, i.e.

```
class A(B):
```

they share a registry.  This means that

1) class A's methods appear in class B's registry, even though class B does not know about class A's methods

2) the registry is re-created when python defines class A so that class B's methods are added to the registry in such a way that they expect to be called with type(self) == type(A) and thus cannot be called just from class B.  (This is the bug identified in the variabilityRegistryBug.py script attached to the JIRA issue for this branch).

This pull requests fixes this issue by:

Creating a fresh registry for each class so that class A and B have their own registries (which fixes issue (1) above, and probably also fixes issue (2)) and adding methods to the registry in such a way that they are not added twice (which would fix issue (2), even if A and B were still sharing a registry).

I have added a unit test to this package to make sure that the decorators work the way I just described.

Note: there is a similar pull request in sims_catUtils
