### PR TITLE
bugfix/SIM-1576/readOnlyRecarrays

### DIFF
--- a/python/lsst/sims/catalogs/measures/instance/CompoundInstanceCatalog.py
+++ b/python/lsst/sims/catalogs/measures/instance/CompoundInstanceCatalog.py
@@ -235,6 +235,10 @@ class CompoundInstanceCatalog(object):
                                 master_colnames[ix][iy] = name_map[ix][name]
 
                     local_recarray = chunk[master_colnames[ix]].view(numpy.recarray)
+
+                    local_recarray.flags['WRITEABLE'] = False # so numpy does not raise a warning
+                                                              # because it thinks we may accidentally
+                                                              # write to this array
                     if new_dtype_list[ix] is None:
                         new_dtype = numpy.dtype([
                                                 tuple([dd.replace(catName+'_','')] + [local_recarray.dtype[dd]]) \


### PR DESCRIPTION
in CompoundInstanceCatalog._write_compound() make local_recarray
read-only so that numpy does not raise any warnings against accidentally
writing to it (apparently, the numpy API is going to change from giving
copies to views when slicing a recarray on its columns; a FutureWarning
was implemented to alert users that their code might break if they were
counting on the slices always being copies)
